### PR TITLE
[thunderbird] build and run thunderbird with lightning

### DIFF
--- a/thunderbird.docker
+++ b/thunderbird.docker
@@ -1,0 +1,38 @@
+FROM ubuntu:14.04
+MAINTAINER Philipp Kewisch "mozilla@kewis.ch"
+
+# Install Thunderbird build dependencies.
+# Packages after "clang" are from https://dxr.mozilla.org/mozilla-central/source/python/mozboot/mozboot/debian.py
+RUN apt-get update && apt-get install -qy mercurial git clang autoconf2.13 build-essential ccache python-dev python-pip python-setuptools unzip uuid zip libasound2-dev libcurl4-openssl-dev libdbus-1-dev libdbus-glib-1-dev libgconf2-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libgtk2.0-dev libgtk-3-dev libiw-dev libnotify-dev libpulse-dev libxt-dev mesa-common-dev python-dbus yasm xvfb
+ENV CC clang
+ENV CXX clang++
+ENV SHELL /bin/bash
+
+# Don't be root.
+RUN useradd -m user
+USER user
+ENV HOME /home/user
+WORKDIR /home/user
+
+# Download Thunderbird's source code.
+RUN hg clone https://hg.mozilla.org/comm-central/ thunderbird
+WORKDIR thunderbird
+RUN python client.py checkout
+
+# Add mozconfig file.
+RUN echo "# Thunderbird build options." >> mozconfig \
+ && echo "ac_add_options --enable-application=mail" >> mozconfig \
+ && echo "ac_add_options --enable-calendar" >> mozconfig \
+ && echo "ac_add_options --disable-crashreporter" >> mozconfig \
+ && echo "ac_add_options --enable-extensions=default,inspector" >> mozconfig \
+ && echo "ac_add_options --with-ccache" >> mozconfig \
+ && echo "" >> mozconfig \
+ && echo "# Building with clang is faster." >> mozconfig \
+ && echo "export CC=clang" >> mozconfig \
+ && echo "export CXX=clang++" >> mozconfig
+
+# Set up mercurial so mach doesn't complain
+RUN mkdir -p /home/user/.mozbuild && ./mozilla/mach mercurial-setup -u
+
+# Build Thunderbird.
+RUN ./mozilla/mach build


### PR DESCRIPTION
Mostly copied from firefox.docker, but removed moz-git-tools because Thunderbird folks usually use hg and I'm not sure we even have a git copy of the comm- repositories. I've tested this locally, and while my disk ran out of space in the very last moment, I did see the final build messages so I think it will work this way.