### PR TITLE
[firefox] Add git commands from moz version-control-tools

### DIFF
--- a/firefox/firefox.dockerfile
+++ b/firefox/firefox.dockerfile
@@ -57,6 +57,9 @@ ADD mozconfig /home/user/firefox/
 # Set up Mercurial extensions for Firefox.
 RUN mkdir -p /home/user/.mozbuild \
  && ./mach mercurial-setup -u
+ENV PATH $PATH:/home/user/.mozbuild/version-control-tools/git/commands
+RUN echo "\n# Add Mozilla's version control tools git commands to the PATH." >> .bashrc \
+ && echo "export PATH=\"\$PATH:/home/user/.mozbuild/version-control-tools/git/commands\"" >> .bashrc
 
 # Set up ESLint for Firefox.
 RUN ./mach eslint --setup


### PR DESCRIPTION
Adds `git mozreview`, even if it will not work on a normal git repo (needs git-cinnabar, see http://mozilla-version-control-tools.readthedocs.io/en/latest/mozreview/install-git.html#mozreview-install-git).
