### PR TITLE
[ubuntu-dev] install cloud9 sdk for all images

### DIFF
--- a/ubuntu-dev/supervisord.conf
+++ b/ubuntu-dev/supervisord.conf
@@ -5,6 +5,9 @@ pidfile = /tmp/supervisord.pid
 [program:sshd]
 user = user
 command = sudo /usr/sbin/sshd -D
+[program:c9sdk]
+user = user
+command = /home/user/.c9sdk/server.js --auth : --collab --listen 0.0.0.0 --port 1337 --workspace /home/user
 [program:xvfb]
 user = user
 command = /usr/bin/Xvfb :99 -screen 0 1280x864x16 -ac -pn -noreset

--- a/ubuntu-dev/ubuntu-dev.dockerfile
+++ b/ubuntu-dev/ubuntu-dev.dockerfile
@@ -121,11 +121,13 @@ RUN mkdir /tmp/vim \
 ENV EDITOR vim
 
 # Install Cloud9 and noVNC.
-RUN curl -L https://raw.githubusercontent.com/c9/install/master/install.sh | bash
+RUN git clone https://github.com/c9/core.git /home/user/.c9sdk \
+ && cd /home/user/.c9sdk \
+ && ./scripts/install-sdk.sh
 RUN git clone https://github.com/kanaka/noVNC /home/user/.novnc/
 
 # Expose remote access ports.
-EXPOSE 22 8088
+EXPOSE 22 1337 8088
 
 # Run all Supervisor services when the container starts.
 CMD [ "/usr/bin/supervisord", "-c", "/etc/supervisord.conf" ]


### PR DESCRIPTION
This appears to be all the changes necessary to install Cloud9 SDK in all Janitor project images.

I'll give it a try.